### PR TITLE
[FEATURE] Support TYPO3 v12 and 13

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,4 +1,7 @@
 <?php
-defined('TYPO3_MODE') || die();
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('datamints_forms_get_prefill', 'Configuration/TypoScript', 'datamints forms get prefill');
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') || die();
+
+ExtensionManagementUtility::addStaticFile('datamints_forms_get_prefill', 'Configuration/TypoScript', 'datamints forms get prefill');

--- a/Documentation/ChangeLog/Index.rst
+++ b/Documentation/ChangeLog/Index.rst
@@ -6,6 +6,12 @@
 Change log
 ==========
 
+Version 1.2.0
+-------------
+
+*   Add support for TYPO3 v13 and v12
+*   Drop support bellow TYPO3 v11
+
 Version 1.0.1
 -------------
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "GPL-2.0-or-later",
     "require": {
-        "typo3/cms-core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+        "typo3/cms-core": "^11.4.0 || ^12.4.0 || ^13.0.0"
     },
     "require-dev": {
         "typo3/testing-framework": "^6.9.0"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,10 +11,10 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.1.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '7.0.0-11.5.99',
+            'typo3' => '7.0.0-13.99.99',
         ],
 		'suggests' => [
-			'form' => '7.0.0-14.99.99',
+			'form' => '7.0.0-13.99.99',
 			'powermail' => '10.0.0-10.4.99',
 		],
         'conflicts' => [],

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,4 +1,0 @@
-<?php
-defined('TYPO3_MODE') || die();
-
-(static function() {})();


### PR DESCRIPTION
Drop Support bellow TYPO3 v11 as they do not support the news constant TYPO3 instead of TYPO3_MODE

Delete empty ext_tables.php

Tested with TYPO3 v12.4.11 and form. Powermail is not tested but versions did not change here

Resolves https://github.com/datamintsGmbH/datamints_forms_get_prefill/issues/2